### PR TITLE
chore: split hist into two packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ffbe314c2bd03c342b9f168dce715ad8f36281eb23172a00970882a9344fe988
 
 build:
-  number: 0
+  number: 1
 outputs:
   - name: hist-core
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ outputs:
       noarch: python
       entry_points:
         - hist=hist.classichist:main
-      script: {{ PYTHON }} -m pip install ".[plot,fit]" -vv
+      script: python -m pip install . -vv
 
     requirements:
       host:
@@ -46,10 +46,10 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage('hist-core', exact=True) }}
-        # The plot requirements - could be changed eventually to be hist-core and hist
+        # The plot requirements
         - matplotlib-base >=3.0
         - mplhep >=0.2.16
-        # The fit plot requirements - could be changed eventually to be hist-core and hist
+        # The fit plot requirements
         - scipy >=1.4
         - iminuit >=2.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,41 +12,52 @@ source:
 
 build:
   number: 0
-  noarch: python
-  entry_points:
-    - hist=hist.classichist:main
-  script: {{ PYTHON }} -m pip install ".[plot,fit]" -vv
+outputs:
+  - name: hist-core
+    build:
+      noarch: python
+      entry_points:
+        - hist=hist.classichist:main
+      script: {{ PYTHON }} -m pip install ".[plot,fit]" -vv
 
-requirements:
-  host:
-    - pip
-    - python >=3.7
-    - hatchling
-    - hatch-vcs
-  run:
-    - boost-histogram ~=1.3.1
-    - histoprint >=2.2
-    - numpy >=1.14.5
-    - python >=3.7
-    # Actually only required for [py<311] but require for all Python versions so this can be noarch: python
-    - typing-extensions
-    # The plot requirements - could be changed eventually to be hist-core and hist
-    - matplotlib-base >=3.0
-    - mplhep >=0.2.16
-    # The fit plot requirements - could be changed eventually to be hist-core and hist
-    - scipy >=1.4
-    - iminuit >=2.0
+    requirements:
+      host:
+        - pip
+        - python >=3.7
+        - hatchling
+        - hatch-vcs
+      run:
+        - boost-histogram ~=1.3.1
+        - histoprint >=2.2
+        - numpy >=1.14.5
+        - python >=3.7
+        # Actually only required for [py<311] but require for all Python versions so this can be noarch: python
+        - typing-extensions
 
-test:
-  imports:
-    - hist
-    - hist.axis
-  commands:
-    - pip check
-    - hist --help
-  requires:
-    - pip
+    test:
+      imports:
+        - hist
+        - hist.axis
+        
+  - name: hist
+    build:
+      noarch: python
 
+    requirements:
+      run:
+        - {{ pin_subpackage('hist-core', exact=True) }}
+        # The plot requirements - could be changed eventually to be hist-core and hist
+        - matplotlib-base >=3.0
+        - mplhep >=0.2.16
+        # The fit plot requirements - could be changed eventually to be hist-core and hist
+        - scipy >=1.4
+        - iminuit >=2.0
+
+    test:
+      imports:
+        - hist
+        - hist.axis
+        
 about:
   home: https://github.com/scikit-hep/hist
   summary: Hist classes and utilities

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 1
 outputs:
-  - name: hist-core
+  - name: hist-base
     build:
       noarch: python
       entry_points:
@@ -45,7 +45,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage('hist-core', exact=True) }}
+        - {{ pin_subpackage('hist-base', exact=True) }}
         # The plot requirements
         - matplotlib-base >=3.0
         - mplhep >=0.2.16


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #5
