### PR TITLE
fix: support boost-histogram 1.4 too

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 26b1ab810d8b10222db5d161d4acaf64aaa04fe6baaed2966d41c1dac5601d06
 
 build:
-  number: 0
+  number: 1
 outputs:
   - name: hist-base
     build:
@@ -27,7 +27,7 @@ outputs:
         - hatchling
         - hatch-vcs
       run:
-        - boost-histogram ~=1.3.1
+        - boost-histogram >=1.3.1,<1.5
         - histoprint >=2.2
         - numpy >=1.14.5
         - python >=3.7


### PR DESCRIPTION

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Missed in the automerged PR.
